### PR TITLE
MemberDTO 에 isNew 를 판단을 위한 created_at 필드 추가

### DIFF
--- a/member-service/src/main/java/io/pranludi/crossfit/member/MemberServiceApplication.java
+++ b/member-service/src/main/java/io/pranludi/crossfit/member/MemberServiceApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableFeignClients
 @EnableConfigurationProperties(ServerProperties.class)
+@EnableFeignClients
+@EnableJpaAuditing
 @SpringBootApplication
 public class MemberServiceApplication {
 

--- a/member-service/src/main/java/io/pranludi/crossfit/member/repository/dto/MemberDTO.java
+++ b/member-service/src/main/java/io/pranludi/crossfit/member/repository/dto/MemberDTO.java
@@ -2,6 +2,7 @@ package io.pranludi.crossfit.member.repository.dto;
 
 import io.pranludi.crossfit.member.domain.MemberGrade;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
@@ -9,9 +10,12 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "member")
 public class MemberDTO implements Persistable<String> {
 
@@ -25,6 +29,8 @@ public class MemberDTO implements Persistable<String> {
     @Enumerated(EnumType.STRING)
     private MemberGrade grade;
     private LocalDateTime lastPaidAt;
+    @CreatedDate
+    private LocalDateTime createdAt;
 
     @Transient
     private boolean isNew = false;
@@ -117,6 +123,14 @@ public class MemberDTO implements Persistable<String> {
         this.lastPaidAt = lastPaidAt;
     }
 
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof MemberDTO memberDTO)) {
@@ -141,6 +155,7 @@ public class MemberDTO implements Persistable<String> {
             ", phoneNumber='" + phoneNumber + '\'' +
             ", grade=" + grade +
             ", lastPaidAt=" + lastPaidAt +
+            ", createdAt=" + createdAt +
             '}';
     }
 }

--- a/member-service/src/test/java/io/pranludi/crossfit/member/repository/MemberRepositoryTest.java
+++ b/member-service/src/test/java/io/pranludi/crossfit/member/repository/MemberRepositoryTest.java
@@ -1,6 +1,7 @@
 package io.pranludi.crossfit.member.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.pranludi.crossfit.member.domain.MemberGrade;
 import io.pranludi.crossfit.member.repository.dto.MemberDTO;
@@ -28,6 +29,23 @@ class MemberRepositoryTest {
 
         // then
         assertEquals(dto.getId(), saved.getId());
+    }
+
+    @Test
+    @Transactional
+    void findById() {
+        // given
+        MemberDTO dto = new MemberDTO("id", "password", "branchId", "name", "email", "phoneNumber", MemberGrade.NORMAL, LocalDateTime.now());
+        dto.setNew(true);
+
+        // when
+        memberRepository.save(dto);
+        assertNotNull(dto.getId());
+        MemberDTO findById = memberRepository.findById(dto.getId()).orElseThrow();
+
+        // then
+        assertEquals(findById.getId(), dto.getId());
+        assertNotNull(findById.getCreatedAt());
     }
 
 }

--- a/member-service/src/test/java/io/pranludi/crossfit/member/rest/AuthControllerTest.java
+++ b/member-service/src/test/java/io/pranludi/crossfit/member/rest/AuthControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -47,6 +48,8 @@ class AuthControllerTest {
     JwtAuthenticationFilter jwtAuthenticationFilter;
     @MockitoBean
     ServerAuthenticationFilter serverAuthenticationFilter;
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @BeforeEach
     public void setup() {

--- a/member-service/src/test/java/io/pranludi/crossfit/member/rest/MemberControllerAddTest.java
+++ b/member-service/src/test/java/io/pranludi/crossfit/member/rest/MemberControllerAddTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -51,6 +52,8 @@ class MemberControllerAddTest {
     JwtAuthenticationFilter jwtAuthenticationFilter;
     @MockitoBean
     ServerAuthenticationFilter serverAuthenticationFilter;
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @BeforeEach
     public void setup() {

--- a/member-service/src/test/java/io/pranludi/crossfit/member/rest/MemberControllerTest.java
+++ b/member-service/src/test/java/io/pranludi/crossfit/member/rest/MemberControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -46,6 +47,8 @@ class MemberControllerTest {
     JwtAuthenticationFilter jwtAuthenticationFilter;
     @MockitoBean
     ServerAuthenticationFilter serverAuthenticationFilter;
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @BeforeEach
     public void setup() {


### PR DESCRIPTION
jpa(SimpleJpaRepository) 의 save 를 할때, db 에 해당 값이 있는지 @id 값으로 확인을 한다.
isNew 에 따라서 바로 insert 할지, select 후 update 할지를 판단 할 수 있다.
그래서, created_at 을 추가해서 신규 가입이라면 isNew = true 그렇지 않다면 false 으로 해서 사용하도록 한다.
